### PR TITLE
can-equal v0.1.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,4 @@
 ThisBuild / organization := props.Organization
-ThisBuild / version := props.ProjectVersion
 ThisBuild / scalaVersion := props.ProjectScalaVersion
 ThisBuild / developers := List(
   Developer("Kevin-Lee", "Kevin Lee", "kevin.code@kevinlee.io", url("https://github.com/Kevin-Lee"))
@@ -35,7 +34,6 @@ lazy val canEqual = Project(props.RepoName, file(props.RepoName))
 
 lazy val props =
   new {
-    final val ProjectVersion = "0.1.0"
 
     final val ProjectScalaVersion = "3.0.0"
 

--- a/changelogs/0.1.0.md
+++ b/changelogs/0.1.0.md
@@ -1,0 +1,11 @@
+## [0.1.0](https://github.com/Kevin-Lee/can-equal/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+milestone%3Amilestone1) - 2021-05-22
+
+## Done
+* Add GitHub Actions workflow files (#2)
+* Add GitHub issue ticket templates (#4)
+* Add `CanEqual` typeclass instances of `Option` (#6)
+* Add `CanEqual` typeclass instance of `Either` (#7)
+* Add `CanEqual` typeclass instances of `Tuple` (#8)
+* Add `CanEqual` typeclass instances of `Option`, `Either` and `Tuple` (#9)
+* Add `CanEqual[Seq[T], Seq[T]]` for pattern matching on `Seq` (#18)
+* Add `CanEqual[Seq[T], Seq[T]]` to `all` (#20)


### PR DESCRIPTION
# can-equal v0.1.0
## [0.1.0](https://github.com/Kevin-Lee/can-equal/issues?utf8=%E2%9C%93&q=is%3Aissue+is%3Aclosed+milestone%3Amilestone1) - 2021-05-22

## Done
* Add GitHub Actions workflow files (#2)
* Add GitHub issue ticket templates (#4)
* Add `CanEqual` typeclass instances of `Option` (#6)
* Add `CanEqual` typeclass instance of `Either` (#7)
* Add `CanEqual` typeclass instances of `Tuple` (#8)
* Add `CanEqual` typeclass instances of `Option`, `Either` and `Tuple` (#9)
* Add `CanEqual[Seq[T], Seq[T]]` for pattern matching on `Seq` (#18)
* Add `CanEqual[Seq[T], Seq[T]]` to `all` (#20)
